### PR TITLE
Minor change to use glpk constants in the example html file

### DIFF
--- a/examples/lp.html
+++ b/examples/lp.html
@@ -20,7 +20,7 @@
                 const lp = {
                     name: 'LP',
                     objective: {
-                        direction: 2,
+                        direction: glpk.GLP_MAX,
                         name: 'obj',
                         vars: [
                         { name: 'x1', coef: 0.6 },
@@ -34,7 +34,7 @@
                             { name: 'x1', coef: 1.0 },
                             { name: 'x2', coef: 2.0 }
                         ],
-                        bnds: { type: 3, ub: 1.0, lb: 0.0 }
+                        bnds: { type: glpk.GLP_UP, ub: 1.0, lb: 0.0 }
                         },
                         {
                         name: 'cons2',
@@ -42,11 +42,11 @@
                             { name: 'x1', coef: 3.0 },
                             { name: 'x2', coef: 1.0 }
                         ],
-                        bnds: { type: 3, ub: 2.0, lb: 0.0 }
+                        bnds: { type: glpk.GLP_UP, ub: 2.0, lb: 0.0 }
                         }
                     ],
                     options: {
-                        msglev: 4
+                        msglev: glpk.GLP_MSG_DBG
                     }
                 };
 


### PR DESCRIPTION
Minor change to use `glpk` constants in the example html file, to make it consistent with the example in the README file.